### PR TITLE
AdversityBot should only focus on demos in Heatseeker 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ test {
 
 dependencies {
     // Fetch the framework jar file
-    compile 'org.rlbot.commons:framework:2.+'
+    compile 'org.rlbot.commons:framework:2.1+'
 
     compile 'org.rlbot.twitch:ActionServer:1.+'
     compile 'org.rlbot.twitch:TwitchBrokerClient:1.+'

--- a/src/main/java/tarehart/rlbot/bots/TacticalBot.kt
+++ b/src/main/java/tarehart/rlbot/bots/TacticalBot.kt
@@ -89,6 +89,10 @@ abstract class TacticalBot(team: Team, playerIndex: Int) : BaseBot(team, playerI
                 println("Game Mode: Spike Rush")
                 SpikeRushTacticsAdvisor()
             }
+            GameMode.HEATSEEKER -> {
+                println("Game Mode: Heat Seeker")
+                SoccerTacticsAdvisor(input)
+            }
         }
     }
 

--- a/src/main/java/tarehart/rlbot/tactics/GameMode.kt
+++ b/src/main/java/tarehart/rlbot/tactics/GameMode.kt
@@ -8,7 +8,8 @@ enum class GameMode {
     SOCCER,
     DROPSHOT,
     HOOPS,
-    SPIKE_RUSH
+    SPIKE_RUSH,
+    HEATSEEKER
 }
 
 object GameModeSniffer {
@@ -28,6 +29,8 @@ object GameModeSniffer {
             gameMode = GameMode.DROPSHOT
         } else if (mode == rlbot.flat.GameMode.Hoops) {
             gameMode = GameMode.HOOPS
+        } else if (mode == rlbot.flat.GameMode.Heatseeker){
+            gameMode = GameMode.HEATSEEKER
         } else {
             gameMode = GameMode.SOCCER
         }


### PR DESCRIPTION
Update `org.rlbot.commons:framework` so heatseeker mode is identifiable cleanly.

With this change, AdversityBot will stop going around in circles in Heatseeker as it constantly switches between the demo  step and the save step.

AdversityBot will still hit the ball on kickoff if they are closest to it.